### PR TITLE
Add latest monaco-editor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "vue": "^3.1.5"
   },
   "peerDependencies": {
-    "monaco-editor": "0.25.x || 0.26.x"
+    "monaco-editor": "0.25.x || 0.26.x || 0.27.x"
   }
 }


### PR DESCRIPTION
Not sure if this requires more testing but noticed the peer dependencies version was missing the latest one.