### PR TITLE
fix: mkdir done sync to prevent state race condition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,14 +127,9 @@ export default function monacoEditorPlugin(options: IMonacoEditorOpts = {}): Plu
       const works = getWorks(options);
 
       // write publicPath
-      fs.mkdir(
+      fs.mkdirSync(
         path.resolve(resolvedConfig.root, resolvedConfig.build.outDir, options.publicPath),
         // resolvedConfig.root + '/' + resolvedConfig.build.outDir + '/' + options.publicPath,
-        (err) => {
-          if (err != null) {
-            throw err;
-          }
-        }
       );
       for (const work of works) {
         if (!fs.existsSync(cacheDir + getFilenameByEntry(work.entry))) {


### PR DESCRIPTION
We are getting sometimes while building following erroor

```
ENOENT: no such file or directory, open '/home/runner/work/platform-client/platform-client/dist/monacoeditorwork/editor.worker.bundle.js'
    at Object.openSync (fs.js:497:3)
    at Object.writeFileSync (fs.js:1528:35)
    at Object.writeBundle (/home/runner/work/platform-client/platform-client/node_modules/vite-plugin-monaco-editor/dist/index.js:114:20)
    at /home/runner/work/platform-client/platform-client/node_modules/rollup/dist/shared/rollup.js:22663:25
    at async Promise.all (index 0)
    at async handleGenerateWrite (/home/runner/work/platform-client/platform-client/node_modules/rollup/dist/shared/rollup.js:23452:9)
    at async doBuild (/home/runner/work/platform-client/platform-client/node_modules/vite/dist/node/chunks/dep-85dbaaa7.js:43150:20)
    at async build (/home/runner/work/platform-client/platform-client/node_modules/vite/dist/node/chunks/dep-85dbaaa7.js:42974:16)
    at async CAC.<anonymous> (/home/runner/work/platform-client/platform-client/node_modules/vite/dist/node/cli.js:737:9
```

It happens because asynchronous `fs.mkdir` sometimes has not yet created directory, so I've replaced asynchronous `fs.mkdir` with `fs.mkdirSync`