### PR TITLE
use config.base to replace '/'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export default function monacoEditorPlugin(options: IMonacoEditorOpts = {}): Plu
     },
     transformIndexHtml(html) {
       const works = getWorks(options);
-      const workerPaths = getWorkPath(works, options);
+      const workerPaths = getWorkPath(works, options, resolvedConfig);
 
       const globals = {
         MonacoEnvironment: `(function (paths) {

--- a/src/workerMiddleware.ts
+++ b/src/workerMiddleware.ts
@@ -12,14 +12,14 @@ export function getFilenameByEntry(entry: string) {
 
 export const cacheDir = 'node_modules/.monaco/';
 
-export function getWorkPath(works: IWorkerDefinition[], options: IMonacoEditorOpts) {
+export function getWorkPath(works: IWorkerDefinition[], options: IMonacoEditorOpts, config: ResolvedConfig) {
   const workerPaths = {};
 
   for (const work of works) {
     if (isCDN(options.publicPath)) {
       workerPaths[work.label] = options.publicPath + '/' + getFilenameByEntry(work.entry);
     } else {
-      workerPaths[work.label] = '/' + options.publicPath + '/' + getFilenameByEntry(work.entry);
+      workerPaths[work.label] = config.base + options.publicPath + '/' + getFilenameByEntry(work.entry);
     }
   }
 


### PR DESCRIPTION
if in `vite.config`, `base` set to a context,for example `/d`,when build, in `index.html`,it will build like this
`"css": "/monacoeditorwork/css.worker.bundle.js",`, but it need to be `"css": "/d/monacoeditorwork/css.worker.bundle.js",`.so use `config.base`to replace '/'.

如果在`vite.config`中设置了`base`上下文,那么最终生成的worker.bundle.js就不能访问.所以用`config.base`来替代'/'