### PR TITLE
fix: issues #21

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "A vite plugin for the Monaco Editor",
   "main": "dist/index.js",
+  "type": "module",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
@@ -48,5 +49,11 @@
   },
   "peerDependencies": {
     "monaco-editor": ">=0.33.0"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   }
 }

--- a/script/updateCDN.js
+++ b/script/updateCDN.js
@@ -1,5 +1,5 @@
-const fse = require("fs-extra")
+import { copySync } from "fs-extra"
 
-fse.copySync("test/dist/a/monacoeditorwork", "cdn", {
+copySync("test/dist/a/monacoeditorwork", "cdn", {
     
 })

--- a/src/workerMiddleware.ts
+++ b/src/workerMiddleware.ts
@@ -1,9 +1,9 @@
 import { Connect, ResolvedConfig } from 'vite';
 import { getWorks, IMonacoEditorOpts, isCDN, resolveMonacoPath } from './index';
 import { IWorkerDefinition, languageWorksByLabel } from './lnaguageWork';
-const esbuild = require('esbuild');
+import * as esbuild from 'esbuild'
 import * as fs from 'fs';
-import path = require('path');
+import * as path from 'path'
 
 export function getFilenameByEntry(entry: string) {
   entry = path.basename(entry, 'js');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
       "outDir": "dist",
       "target": "ES6",
-      "module": "commonjs",
+      "module": "ES6",
       "moduleResolution": "node",
       "declaration": true,
     }


### PR DESCRIPTION
All bundled scripts are in ESM format now, so default export will work.