### PR TITLE
fix: fix empty options and backslash escape missing in webpage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export interface IMonacoEditorOpts {
   globalAPI?: boolean;
 }
 
-export default function monacoEditorPlugin(options: IMonacoEditorOpts): Plugin {
+export default function monacoEditorPlugin(options: IMonacoEditorOpts = {}): Plugin {
   const languageWorkers =
     options.languageWorkers || (Object.keys(languageWorksByLabel) as EditorLanguageWorks[]);
   const publicPath = options.publicPath || 'monacoeditorwork';
@@ -98,7 +98,7 @@ export default function monacoEditorPlugin(options: IMonacoEditorOpts): Plugin {
             globalAPI: ${globalAPI},
             getWorkerUrl : function (moduleId, label) {
               var result =  paths[label];
-              if (/^((http:)|(https:)|(file:)|(\\/\\/))/.test(result)) {
+              if (/^((http:)|(https:)|(file:)|(\\\\/\\\\/))/.test(result)) {
                 var currentUrl = String(window.location);
                 var currentOrigin = currentUrl.substr(0, currentUrl.length - window.location.hash.length - window.location.search.length - window.location.pathname.length);
                 if (result.substring(0, currentOrigin.length) !== currentOrigin) {


### PR DESCRIPTION
In the docs, the following init script will throw error as `options` is undefined
```js
import { defineConfig } from 'vite';
import monacoEditorPlugin from 'vite-plugin-monaco-editor';

export default defineConfig({
  plugins: [monacoEditorPlugin()],
});
```
This pr fix this case.

The other problem is `\\/\\/` will write as `//` in the page which will make the regex as error in `<script>`. This pr fix this case.
![image](https://github.com/vdesjs/vite-plugin-monaco-editor/assets/7945757/96965561-4950-4ce5-b82b-7aa1de9132e2)
